### PR TITLE
Add new function time check and review old results

### DIFF
--- a/config.json
+++ b/config.json
@@ -32,7 +32,7 @@
   "test_cadence": "0 0 5 * * Sat",
   "enable_cron": false,
   "mail_test_report": {
-    "from": "wanming.lin@intel.com",
+    "from": "hongjuan.wang@intel.com",
     "to": [
       "chromiumopt@intel.com",
       "greg.w.meyer@intel.com",
@@ -49,9 +49,9 @@
     ]
   },
   "mail_dev_notice": {
-    "from": "wanming.lin@intel.com",
+    "from": "hongjuan.wang@intel.com",
     "to": [
-      "wanming.lin@intel.com"
+      "hongjuan.wang@intel.com"
     ]
   },
   "result_server": {

--- a/src/report/review_report.js
+++ b/src/report/review_report.js
@@ -1,0 +1,35 @@
+"use strict";
+const checkReport = require('./check_report.js');
+
+/**
+ * Check all the test results for delivering one round test report in old-results
+ * @param {String} channel browser channel in {Stable, Beta, Dev, Canary}, the first letter must be capitalized
+ * @param {String} version browser version, e.g. 88.0.4324.146
+ * @param {String} platform test platform, default is Windows
+ */
+async function main(channel, version, platform) {
+    try {
+        const reviewReport = await checkReport.checkReviewReports(channel, version, platform);
+        console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> reviewReport:');
+        console.log(reviewReport);
+        await checkReport.moveReportFiles(reviewReport.report, platform, 'new-results');
+    } catch (err) {
+        console.log(err);
+        let subject = 'ERROR: must give 2 or 3 params(chrome channel name, chrome version and test platform which has a default value "Windows"), e.g. `node src/report/review_report.js Canary 90.0.4402.0`';
+        console.log(subject);
+    }
+    return Promise.resolve();
+}
+
+var myArgs = process.argv.slice(2);
+console.log('myArgs: ', myArgs);
+var channel = myArgs[0];
+console.log('channel: ', channel);
+var version = myArgs[1];
+console.log('version: ', version);
+var platform = myArgs[2] ? myArgs[2] : 'Windows';
+console.log('platform: ', platform);
+
+(async () => {
+    await main(channel, version, platform);
+})();


### PR DESCRIPTION
    feat:   add new function reset test time to the same before translate json to excel file
    
    feat:   add new function review_report.js for rollback wrong data to new-results folder,
    so that we can modified or delete data, and then send report again
